### PR TITLE
Fix: There is an issue in main.go file please fix that.

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,6 @@ package main
 import "fmt"
 
 func main() {
-	fmt.Prin("hello world")
-
+    // Corrected the typo from 'fmt.Prin' to 'fmt.Println'
+    fmt.Println("hello world")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"testing"
+	"os"
+	"bytes"
+	"fmt"
+)
+
+func TestMainFunction(t *testing.T) {
+	// Capture the output of the main function
+	rescueStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	main()
+
+	// Restore the original stdout
+	w.Close()
+	os.Stdout = rescueStdout
+
+	out, _ := io.ReadAll(r)
+
+	// Check if the output of the main function is as expected
+	if string(out) != "hello world\n" {
+		t.Errorf("Unexpected output. Expected 'hello world\n', got %s", out)
+	}
+}


### PR DESCRIPTION
The issue in the main.go file was a typo in the 'fmt.Prin' function call. The correct function to print to the console in Go is 'fmt.Println'. The typo has been corrected in the updated code.