### PR TITLE
Fix: The issue occurs because GetTaskByDueDate() doesn't implemented correctly.

### DIFF
--- a/automation-engine/domain/reminder/repository/repository.go
+++ b/automation-engine/domain/reminder/repository/repository.go
@@ -1,0 +1,26 @@
+package repository
+
+import (
+	"github.com/jinzhu/gorm"
+	"github.com/rohanchauhan02/automation-engine/models"
+)
+
+type Repository struct {
+	DB *gorm.DB
+}
+
+func (r *Repository) GetTaskByDueDate(interval int64) ([]models.Task, error) {
+	var tasks []models.Task
+	// Convert interval to time.Duration
+	intervalDuration := time.Duration(interval) * time.Minute
+	// Get the current time
+	currentTime := time.Now()
+	// Calculate the due date
+	dueDate := currentTime.Add(intervalDuration)
+	// Fetch tasks due within the interval
+	err := r.DB.Where("due_date <= ?", dueDate).Find(&tasks).Error
+	if err != nil {
+		return nil, err
+	}
+	return tasks, nil
+}

--- a/automation-engine/domain/reminder/repository/repository_test.go
+++ b/automation-engine/domain/reminder/repository/repository_test.go
@@ -1,0 +1,43 @@
+package repository
+
+import (
+	"github.com/jinzhu/gorm"
+	"github.com/rohanchauhan02/automation-engine/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+	"time"
+)
+
+type MockDB struct {
+	mock.Mock
+}
+
+func (m *MockDB) Where(query interface{}, args ...interface{}) *gorm.DB {
+	return m.Called(query, args).Get(0).(*gorm.DB)
+}
+
+func (m *MockDB) Find(out interface{}) *gorm.DB {
+	return m.Called(out).Get(0).(*gorm.DB)
+}
+
+func TestRepository_GetTaskByDueDate(t *testing.T) {
+	// Mock DB
+	mockDB := new(MockDB)
+	// Mock current time
+	mockTime := time.Now()
+	// Mock interval
+	mockInterval := int64(60)
+	// Mock tasks
+	mockTasks := []models.Task{{ID: 1, Name: 'Task 1', DueDate: mockTime.Add(time.Duration(mockInterval) * time.Minute)}}
+	// Mock repository
+	mockRepo := &Repository{DB: mockDB}
+	// Mock DB calls
+	mockDB.On("Where", "due_date <= ?", mock.Anything).Return(mockDB)
+	mockDB.On("Find", &[]models.Task{}).Return(mockDB)
+	// Call function
+	tasks, err := mockRepo.GetTaskByDueDate(mockInterval)
+	// Assert function call
+	assert.NoError(t, err)
+	assert.Equal(t, mockTasks, tasks)
+}


### PR DESCRIPTION
The issue seems to be with the implementation of the GetTaskByDueDate() function. This function is supposed to fetch tasks that are due within a certain interval. However, it seems that it's not working as expected. The problem could be due to incorrect SQL query, wrong handling of the interval parameter, or incorrect conversion of the due date to the required format. Since the actual implementation of the function is not provided, I will provide a general fix. The fix will involve correctly implementing the GetTaskByDueDate() function to fetch tasks due within the provided interval. This will involve writing the correct SQL query and handling the interval parameter correctly.