### PR TITLE
Fix: The issue occurs because GetTaskByDueDate() doesn't implemented correctly.

### DIFF
--- a/automation-engine/domain/reminder/repository/repository.go
+++ b/automation-engine/domain/reminder/repository/repository.go
@@ -1,0 +1,19 @@
+package repository
+
+import (
+	"github.com/jinzhu/gorm"
+	"github.com/rohanchauhan02/automation-engine/models"
+)
+
+type Repository struct {
+	DB *gorm.DB
+}
+
+func (r *Repository) GetTaskByDueDate(interval int64) ([]models.Task, error) {
+	var tasks []models.Task
+	err := r.DB.Where("due_date <= ?", time.Now().Add(time.Duration(interval)*time.Minute)).Find(&tasks).Error
+	if err != nil {
+		return nil, err
+	}
+	return tasks, nil
+}

--- a/automation-engine/domain/reminder/repository/repository_test.go
+++ b/automation-engine/domain/reminder/repository/repository_test.go
@@ -1,0 +1,25 @@
+package repository_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+	"time"
+)
+
+type MockDB struct {
+	mock.Mock
+}
+
+func (m *MockDB) Where(query interface{}, args ...interface{}) *gorm.DB {
+	return m.Called(query, args).Get(0).(*gorm.DB)
+}
+
+func TestGetTaskByDueDate(t *testing.T) {
+	mockDB := new(MockDB)
+	repo := &repository.Repository{DB: mockDB}
+	mockDB.On("Where", "due_date <= ?", time.Now().Add(time.Duration(1)*time.Minute)).Return(&gorm.DB{})
+	tasks, err := repo.GetTaskByDueDate(1)
+	assert.Nil(t, err)
+	assert.NotNil(t, tasks)
+}

--- a/domain/reminder/usecase/scheduler.go
+++ b/domain/reminder/usecase/scheduler.go
@@ -1,0 +1,26 @@
+package usecase
+
+import (
+	"fmt"
+	"log"
+	"time"
+)
+
+func (u *usecase) Reminder() {
+	// Run reminder in every minute
+	const interval = 1
+	ticker := time.NewTicker(interval * time.Minute)
+
+	for {
+		select {
+		case <-ticker.C:
+			tasks, err := u.repository.GetTaskByDueDate(interval)
+			if err != nil {
+				log.Println("Error fetching data from DB:", err)
+			}
+			if len(tasks) == 0 {
+				fmt.Println("No task in bucket")
+			}
+			for _, task := range tasks {
+				userID := task.UserID
+				user, err := u....

--- a/domain/reminder/usecase/scheduler_test.go
+++ b/domain/reminder/usecase/scheduler_test.go
@@ -1,0 +1,24 @@
+package usecase_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+type MockRepository struct {
+	mock.Mock
+}
+
+func (m *MockRepository) GetTaskByDueDate(interval int64) ([]models.Task, error) {
+	args := m.Called(interval)
+	return args.Get(0).([]models.Task), args.Error(1)
+}
+
+func TestReminder(t *testing.T) {
+	mockRepo := new(MockRepository)
+	usecase := &usecase.Usecase{repository: mockRepo}
+	mockRepo.On("GetTaskByDueDate", 1).Return([]models.Task{}, nil)
+	usecase.Reminder()
+	mockRepo.AssertExpectations(t)
+}


### PR DESCRIPTION
The issue seems to be with the implementation of the GetTaskByDueDate() function. This function is supposed to fetch tasks that are due based on the interval provided. However, it's not clear how the function is implemented. The function could be failing to fetch the tasks due to a variety of reasons such as incorrect SQL query, incorrect handling of the interval parameter, or failure to handle errors properly. The solution would be to review the implementation of the GetTaskByDueDate() function and ensure it correctly fetches tasks based on the due date. Also, proper error handling should be implemented to ensure any errors that occur during the execution of the function are properly logged and handled.